### PR TITLE
Improve GPTFF compatibility, ASE calculator paths, and TorchSim interfacePr/gptff core compat optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ p = ASECalculator(model_weight, device) # Initialize the model and load weights
 adp = AseAtomsAdaptor()
 struc = Structure.from_file('POSCAR_structure')
 atoms = adp.get_atoms(struc)
-atoms.set_calculator(p)
+atoms.calc = p
 
 energy = atoms.get_potential_energy() # unit (eV)
 forces = atoms.get_forces() # unit (eV/Å)
@@ -113,7 +113,7 @@ struc = Structure.from_file('POSCAR_structure') # Read structure
 
 adp = AseAtomsAdaptor()
 atoms = adp.get_atoms(struc)
-atoms.set_calculator(p)
+atoms.calc = p
 
 optimizer = BFGS(atoms)
 optimizer.run(fmax=0.01, steps=1000)
@@ -139,7 +139,7 @@ struc = Structure.from_file('POSCAR_structure') # Read structure
 
 adp = AseAtomsAdaptor()
 atoms = adp.get_atoms(struc)
-atoms.set_calculator(p)
+atoms.calc = p
 
 save_dir = './results_path'
 os.makedirs(save_dir, exist_ok=True)

--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ dyn.run(100000)
 
 **TorchSim interface (optional):**
 
-Install the optional TorchSim dependency with `pip install -e ".[torchsim]"`.
 The TorchSim model uses GPTFF V1/V2 checkpoints directly and can be used with
 TorchSim states and integrators.
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,34 @@ dyn.run(100000)
 
 ```
 
+**TorchSim interface (optional):**
+
+Install the optional TorchSim dependency with `pip install -e ".[torchsim]"`.
+The TorchSim model uses GPTFF V1/V2 checkpoints directly and can be used with
+TorchSim states and integrators.
+
+```python
+import torch
+import torch_sim as ts
+from ase.io import read
+from gptff.model.torchsim import GPTFFTorchSimModel
+
+model_weight = "pretrained/gptff_v1.pth"
+model = GPTFFTorchSimModel(model_weight,
+                           device="cuda",
+                           dtype=torch.float32,
+                           compute_forces=True,
+                           compute_stress=True)
+
+atoms = read("POSCAR_structure")
+state = ts.initialize_state(atoms, model.device, model.dtype)
+results = model(state)
+
+energy = results["energy"]   # unit (eV)
+forces = results["forces"]   # unit (eV/Å)
+stress = results["stress"]   # unit (eV/Å^3); use stress_unit="GPa" to match ASE
+```
+
 ## Model training
 
 `config.json` would be training parameters, you could specify data path in this file.

--- a/gptff/model/model.py
+++ b/gptff/model/model.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext
+
 import torch
 import torch.nn as nn
 from torch.nn.utils.rnn import pad_sequence
@@ -12,6 +14,21 @@ def _padding_mask(n_atoms):
     max_len = int(n_atoms.max().item())
     positions = torch.arange(max_len, device=n_atoms.device)
     return positions.unsqueeze(0) >= n_atoms.unsqueeze(1)
+
+
+def _cuda_math_sdp_context():
+    try:
+        from torch.nn.attention import SDPBackend, sdpa_kernel
+
+        return sdpa_kernel([SDPBackend.MATH])
+    except (ImportError, AttributeError):
+        if torch.cuda.is_available():
+            return torch.backends.cuda.sdp_kernel(
+                enable_flash=False,
+                enable_math=True,
+                enable_mem_efficient=False,
+            )
+        return nullcontext()
 
 
 def _three_body_indices(nbr_atoms, bond_pairs_indices, n_bond_pairs_bond):
@@ -212,7 +229,11 @@ class TransformerBlock(nn.Module):
         self.encoder = nn.TransformerEncoder(encoder_layer, num_layers=1)
 
     def forward(self, atom_fea, masks):
-        out = self.encoder(atom_fea, src_key_padding_mask=masks)
+        if self.training and atom_fea.is_cuda:
+            with _cuda_math_sdp_context():
+                out = self.encoder(atom_fea, src_key_padding_mask=masks)
+        else:
+            out = self.encoder(atom_fea, src_key_padding_mask=masks)
         return out
 
 class tModLodaer_t(_RuntimeModelBase):

--- a/gptff/model/model.py
+++ b/gptff/model/model.py
@@ -220,7 +220,7 @@ class tModLodaer_t(nn.Module):
         n_bond_pairs_bond: [M]
         """
 
-        atom_fea = atom_fea.squeeze()
+        atom_fea = atom_fea.view(-1)
         atom_fea = self.atom_embedding(atom_fea) # N, atom_fea_len
         bonds_dist = ebf(bonds_r.unsqueeze(-1), 5.0, self.device) # M, 16
         bonds = ebf(bonds_r.unsqueeze(-1), 5.0, self.device) # M, 16
@@ -320,7 +320,7 @@ class tModLodaer(nn.Module):
         n_bond_pairs_bond: [M]
         """
 
-        atom_fea = atom_fea.squeeze()
+        atom_fea = atom_fea.view(-1)
         atom_fea = self.atom_embedding(atom_fea) # N, atom_fea_len
         bonds_dist = ebf(bonds_r.unsqueeze(-1), 5.0, self.device) # M, 16
         bonds = ebf(bonds_r.unsqueeze(-1), 5.0, self.device) # M, 16

--- a/gptff/model/model.py
+++ b/gptff/model/model.py
@@ -4,6 +4,46 @@ from torch.nn.utils.rnn import pad_sequence
 import numpy as np
 
 
+def _batch_index(n_atoms):
+    return torch.repeat_interleave(torch.arange(n_atoms.shape[0], device=n_atoms.device), n_atoms)
+
+
+def _padding_mask(n_atoms):
+    max_len = int(n_atoms.max().item())
+    positions = torch.arange(max_len, device=n_atoms.device)
+    return positions.unsqueeze(0) >= n_atoms.unsqueeze(1)
+
+
+def _three_body_indices(nbr_atoms, bond_pairs_indices, n_bond_pairs_bond):
+    nbr_i = nbr_atoms[:, 0]
+    nbr_j = nbr_atoms[:, 1]
+    pair_j = bond_pairs_indices[:, 0]
+    pair_k = bond_pairs_indices[:, 1]
+    bond_pair_target = torch.repeat_interleave(
+        torch.arange(n_bond_pairs_bond.shape[0], device=n_bond_pairs_bond.device),
+        n_bond_pairs_bond,
+    )
+    return nbr_i, nbr_j, nbr_i.index_select(0, pair_k), nbr_j.index_select(0, pair_j), nbr_j.index_select(0, pair_k), bond_pair_target
+
+
+def ebf(d_ij, rcut, device=None, filters=None):
+    if filters is None:
+        filter_device = d_ij.device if device is None else device
+        filters = torch.arange(16, device=filter_device, dtype=d_ij.dtype)
+    else:
+        filters = filters.to(device=d_ij.device, dtype=d_ij.dtype)
+    scale = (2.0 / float(rcut)) ** 0.5
+    return scale * torch.sin(filters * (torch.pi / float(rcut)) * d_ij) / d_ij
+
+
+class _RuntimeModelBase(nn.Module):
+    def _init_runtime_buffers(self):
+        self.register_buffer("ebf_filters", torch.arange(16, dtype=torch.float32), persistent=False)
+
+    def _radial_basis(self, distances, rcut):
+        return ebf(distances, rcut, filters=self.ebf_filters)
+
+
 class ThreeBody(nn.Module):
     def __init__(self, atom_fea_len, nbr_fea_len, device):
         super(ThreeBody, self).__init__()
@@ -22,7 +62,7 @@ class ThreeBody(nn.Module):
         self.W_1 = nn.Linear(nbr_fea_len, nbr_fea_len)
         self.W_2 = nn.Linear(nbr_fea_len, nbr_fea_len)
 
-    def forward(self, atom_fea, edge_ij, triple_dist_ij, triple_dist_ik, triple_a_jik, nbr_atoms, bond_pairs_indices, n_bond_pairs_bond):
+    def forward(self, atom_fea, edge_ij, triple_dist_ij, triple_dist_ik, triple_a_jik, nbr_atoms, bond_pairs_indices, n_bond_pairs_bond, three_body_indices=None):
         """
         atom_fea: [N, atom_fea_len]
         edge_ij: [M, nbr_fea_len]
@@ -33,9 +73,12 @@ class ThreeBody(nn.Module):
         n_bond_pairs_bond: [M]
         """
 
-        triple_i_indices = nbr_atoms[:, 0][bond_pairs_indices[:, 1]]
-        triple_j_indices = nbr_atoms[:, 1][bond_pairs_indices[:, 0]]
-        triple_k_indices = nbr_atoms[:, 1][bond_pairs_indices[:, 1]]
+        if three_body_indices is None:
+            _, _, triple_i_indices, triple_j_indices, triple_k_indices, bond_pair_target = _three_body_indices(
+                nbr_atoms, bond_pairs_indices, n_bond_pairs_bond
+            )
+        else:
+            _, _, triple_i_indices, triple_j_indices, triple_k_indices, bond_pair_target = three_body_indices
         atom_fea_ik = torch.cat([atom_fea[triple_i_indices],
                              atom_fea[triple_j_indices],
                              atom_fea[triple_k_indices],
@@ -51,7 +94,7 @@ class ThreeBody(nn.Module):
         # mat = angles_mat * bonds_mat * atom_fea_ik
 
         # atom_nbr_fea_ik = self.sig(mat)  # N, M, M-1, atom_fea
-        edge_ij = torch.index_add(edge_ij, 0, torch.repeat_interleave(torch.arange(n_bond_pairs_bond.shape[0]).to(self.device), n_bond_pairs_bond), atom_fea_ik)
+        edge_ij = torch.index_add(edge_ij, 0, bond_pair_target, atom_fea_ik)
         return edge_ij
 
 class EdgeUpdate(nn.Module):
@@ -66,9 +109,13 @@ class EdgeUpdate(nn.Module):
         self.W_r = nn.Linear(16, nbr_fea_len)
         self.W_3 = nn.Linear(nbr_fea_len, nbr_fea_len)
 
-    def forward(self, atom_fea, edge_ij, nbr_atoms, bonds_r):
-        atom_nbr_fea = torch.cat([atom_fea[nbr_atoms[:, 0]],
-                                  atom_fea[nbr_atoms[:, 1]],
+    def forward(self, atom_fea, edge_ij, nbr_atoms, bonds_r, nbr_i=None, nbr_j=None):
+        if nbr_i is None:
+            nbr_i = nbr_atoms[:, 0]
+        if nbr_j is None:
+            nbr_j = nbr_atoms[:, 1]
+        atom_nbr_fea = torch.cat([atom_fea[nbr_i],
+                                  atom_fea[nbr_j],
                                   edge_ij], dim=-1)
         
         edge_ij = self.swish(self.W_1(atom_nbr_fea)) * self.sig(self.W_2(atom_nbr_fea))
@@ -92,22 +139,21 @@ class ConvLayer(nn.Module):
         self.W_1 = nn.Linear(2 * atom_fea_len, atom_fea_len)
         self.W_2 = nn.Linear(2 * atom_fea_len, atom_fea_len)
 
-    def forward(self, atom_fea, edge_ij, bonds_r, nbr_atoms):
-        atom_nbr_fea = torch.cat([atom_fea[nbr_atoms[:, 0]],
-                                  atom_fea[nbr_atoms[:, 1]],
+    def forward(self, atom_fea, edge_ij, bonds_r, nbr_atoms, nbr_i=None, nbr_j=None):
+        if nbr_i is None:
+            nbr_i = nbr_atoms[:, 0]
+        if nbr_j is None:
+            nbr_j = nbr_atoms[:, 1]
+        atom_nbr_fea = torch.cat([atom_fea[nbr_i],
+                                  atom_fea[nbr_j],
                                   edge_ij], dim=-1)
         atom_gated_fea = self.swish(self.fc_full(atom_nbr_fea))
 
         nbr_all = self.swish(self.W_1(atom_gated_fea)) * self.sig(self.W_2(atom_gated_fea))
         nbr_all = nbr_all * self.W_r(bonds_r)
-        atom_fea = torch.index_add(atom_fea, 0, nbr_atoms[:, 0], nbr_all.float())
+        atom_fea = torch.index_add(atom_fea, 0, nbr_i, nbr_all.float())
 
         return atom_fea
-
-def ebf(d_ij, rcut, device):
-    radius = rcut
-    filters = torch.arange(0, 16, 1).to(device)
-    return torch.sqrt(torch.tensor(2.) / radius) * torch.sin(filters * torch.pi / radius * d_ij) / d_ij
 
 class Attention(nn.Module):
     def __init__(self, d_model, heads=8, dim_head=64):
@@ -169,11 +215,12 @@ class TransformerBlock(nn.Module):
         out = self.encoder(atom_fea, src_key_padding_mask=masks)
         return out
 
-class tModLodaer_t(nn.Module):
+class tModLodaer_t(_RuntimeModelBase):
     def __init__(self, CFG
                         ):
         
         super(tModLodaer_t, self).__init__()
+        self._init_runtime_buffers()
 
         atom_fea_len = CFG.node_feature_len
         nbr_fea_len = CFG.edge_feature_len
@@ -222,49 +269,49 @@ class tModLodaer_t(nn.Module):
 
         atom_fea = atom_fea.view(-1)
         atom_fea = self.atom_embedding(atom_fea) # N, atom_fea_len
-        bonds_dist = ebf(bonds_r.unsqueeze(-1), 5.0, self.device) # M, 16
-        bonds = ebf(bonds_r.unsqueeze(-1), 5.0, self.device) # M, 16
+        bonds_dist = self._radial_basis(bonds_r.unsqueeze(-1), 5.0) # M, 16
         
-        triple_dist_ij = ebf(triple_dist_ij.unsqueeze(-1), 3.5, self.device)
-        triple_dist_ik = ebf(triple_dist_ik.unsqueeze(-1), 3.5, self.device)
+        triple_dist_ij = self._radial_basis(triple_dist_ij.unsqueeze(-1), 3.5)
+        triple_dist_ik = self._radial_basis(triple_dist_ik.unsqueeze(-1), 3.5)
 
-        edge_ij = self.w_b(bonds)
+        three_body_indices = _three_body_indices(nbr_atoms, bond_pairs_indices, n_bond_pairs_bond)
+        nbr_i, nbr_j = three_body_indices[:2]
+        atom_batch_index = _batch_index(n_atoms)
 
-        edge_ij = torch.cat([atom_fea[nbr_atoms[:, 0]],
-                          atom_fea[nbr_atoms[:, 1]],
+        edge_ij = self.w_b(bonds_dist)
+
+        edge_ij = torch.cat([atom_fea[nbr_i],
+                          atom_fea[nbr_j],
                           edge_ij
                           ], dim=-1)
 
         edge_ij = self.w_eij(edge_ij) * self.w_r(bonds_dist)
         
-        max_len = torch.max(n_atoms)
-        # print(max_len)
-        masks = torch.ones(len(n_atoms), max_len)
-
-        for ii in range(len(masks)):
-            masks[ii, :n_atoms[ii]] = 0.0
-
-        masks = masks.to(torch.bool).to(self.device) # bs, max_len
+        masks = _padding_mask(n_atoms)
+        n_atoms_list = [int(n_atom) for n_atom in n_atoms.detach().cpu().tolist()]
 
         for edge_func, conv, three, transformer, norm1, norm2 in zip(self.edge_updates, self.convs, self.three, self.transformers, self.norms1, self.norms2):
-            edge_ij = three(atom_fea, edge_ij, triple_dist_ij, triple_dist_ik, triple_a_jik, nbr_atoms, bond_pairs_indices, n_bond_pairs_bond)
-            edge_ij = edge_ij + edge_func(atom_fea, edge_ij, nbr_atoms, bonds_dist)
-            atom_fea = norm1(conv(atom_fea, edge_ij, bonds_dist, nbr_atoms))
+            edge_ij = three(
+                atom_fea,
+                edge_ij,
+                triple_dist_ij,
+                triple_dist_ik,
+                triple_a_jik,
+                nbr_atoms,
+                bond_pairs_indices,
+                n_bond_pairs_bond,
+                three_body_indices=three_body_indices,
+            )
+            edge_ij = edge_ij + edge_func(atom_fea, edge_ij, nbr_atoms, bonds_dist, nbr_i=nbr_i, nbr_j=nbr_j)
+            atom_fea = norm1(conv(atom_fea, edge_ij, bonds_dist, nbr_atoms, nbr_i=nbr_i, nbr_j=nbr_j))
 
-            atom_fea_list = []
-
-            c_atom = 0
-            for n_atom in n_atoms:
-                atom_fea_list.append(atom_fea[c_atom:c_atom+n_atom])
-                c_atom += n_atom
-
-            atom_fea_list = pad_sequence(atom_fea_list, batch_first=True) # bs, seq_len, fea_len
+            atom_fea_list = pad_sequence(torch.split(atom_fea, n_atoms_list), batch_first=True) # bs, seq_len, fea_len
 
             # atom_fea = torch.cat([transformer(torch.index_select(atom_fea, 0, idx_map)) for idx_map in crystal_atom_idx], dim=0) + atom_fea
-            atom_fea = norm2(transformer(atom_fea_list, masks))[masks == False, :] + atom_fea # [masks == False, :]
+            atom_fea = norm2(transformer(atom_fea_list, masks))[~masks, :] + atom_fea # [masks == False, :]
 
-        cry_fea = torch.zeros((len(n_atoms), self.atom_fea_len)).to(self.device)
-        cry_fea = torch.index_add(cry_fea, 0, torch.repeat_interleave(torch.arange(n_atoms.shape[0]).to(self.device), n_atoms), atom_fea)
+        cry_fea = atom_fea.new_zeros((n_atoms.shape[0], self.atom_fea_len))
+        cry_fea = torch.index_add(cry_fea, 0, atom_batch_index, atom_fea)
         
         cry_fea = self.swish(self.fc1(cry_fea))
         cry_fea = self.swish(self.fc2(cry_fea))
@@ -274,11 +321,12 @@ class tModLodaer_t(nn.Module):
         return out
 
 
-class tModLodaer(nn.Module):
+class tModLodaer(_RuntimeModelBase):
     def __init__(self, CFG
                         ):
         
         super(tModLodaer, self).__init__()
+        self._init_runtime_buffers()
         
         atom_fea_len = CFG.node_feature_len
         nbr_fea_len = CFG.edge_feature_len
@@ -322,28 +370,41 @@ class tModLodaer(nn.Module):
 
         atom_fea = atom_fea.view(-1)
         atom_fea = self.atom_embedding(atom_fea) # N, atom_fea_len
-        bonds_dist = ebf(bonds_r.unsqueeze(-1), 5.0, self.device) # M, 16
-        bonds = ebf(bonds_r.unsqueeze(-1), 5.0, self.device) # M, 16
+        bonds_dist = self._radial_basis(bonds_r.unsqueeze(-1), 5.0) # M, 16
         
-        triple_dist_ij = ebf(triple_dist_ij.unsqueeze(-1), 3.5, self.device)
-        triple_dist_ik = ebf(triple_dist_ik.unsqueeze(-1), 3.5, self.device)
+        triple_dist_ij = self._radial_basis(triple_dist_ij.unsqueeze(-1), 3.5)
+        triple_dist_ik = self._radial_basis(triple_dist_ik.unsqueeze(-1), 3.5)
 
-        edge_ij = self.w_b(bonds)
+        three_body_indices = _three_body_indices(nbr_atoms, bond_pairs_indices, n_bond_pairs_bond)
+        nbr_i, nbr_j = three_body_indices[:2]
+        atom_batch_index = _batch_index(n_atoms)
 
-        edge_ij = torch.cat([atom_fea[nbr_atoms[:, 0]],
-                          atom_fea[nbr_atoms[:, 1]],
+        edge_ij = self.w_b(bonds_dist)
+
+        edge_ij = torch.cat([atom_fea[nbr_i],
+                          atom_fea[nbr_j],
                           edge_ij
                           ], dim=-1)
 
         edge_ij = self.w_eij(edge_ij) * self.w_r(bonds_dist)
         
         for edge_func, conv, three in zip(self.edge_updates, self.convs, self.three):
-            edge_ij = three(atom_fea, edge_ij, triple_dist_ij, triple_dist_ik, triple_a_jik, nbr_atoms, bond_pairs_indices, n_bond_pairs_bond)
-            edge_ij = edge_ij + edge_func(atom_fea, edge_ij, nbr_atoms, bonds_dist)
-            atom_fea = conv(atom_fea, edge_ij, bonds_dist, nbr_atoms)
+            edge_ij = three(
+                atom_fea,
+                edge_ij,
+                triple_dist_ij,
+                triple_dist_ik,
+                triple_a_jik,
+                nbr_atoms,
+                bond_pairs_indices,
+                n_bond_pairs_bond,
+                three_body_indices=three_body_indices,
+            )
+            edge_ij = edge_ij + edge_func(atom_fea, edge_ij, nbr_atoms, bonds_dist, nbr_i=nbr_i, nbr_j=nbr_j)
+            atom_fea = conv(atom_fea, edge_ij, bonds_dist, nbr_atoms, nbr_i=nbr_i, nbr_j=nbr_j)
 
-        cry_fea = torch.zeros((len(n_atoms), self.atom_fea_len)).to(self.device)
-        cry_fea = torch.index_add(cry_fea, 0, torch.repeat_interleave(torch.arange(n_atoms.shape[0]).to(self.device), n_atoms), atom_fea)
+        cry_fea = atom_fea.new_zeros((n_atoms.shape[0], self.atom_fea_len))
+        cry_fea = torch.index_add(cry_fea, 0, atom_batch_index, atom_fea)
         
         cry_fea = self.swish(self.fc1(cry_fea))
         cry_fea = self.swish(self.fc2(cry_fea))

--- a/gptff/model/mpredict.py
+++ b/gptff/model/mpredict.py
@@ -1,7 +1,6 @@
 import numpy as np
 from ase import Atoms
 from ase.calculators.calculator import Calculator, all_changes
-from pymatgen.io.ase import AseAtomsAdaptor
 from gptff.model import model 
 import torch
 from typing import Optional, Sequence
@@ -39,13 +38,13 @@ def _load_checkpoint(model_path, device):
 
 
 def _pair_and_triple_features(coords, offsets, lattice, n_atoms, pairs_count, nbr_atoms, bond_pairs_indices, device, strain=None):
-    eye = torch.eye(3, dtype=torch.float32, device=device)[None, :, :]
     if strain is None:
-        strain = torch.zeros_like(lattice, dtype=torch.float32)
-
-    lattices = torch.matmul(lattice, eye + strain)
-    strains = torch.repeat_interleave(strain, n_atoms, dim=0)
-    coords = torch.matmul(coords.unsqueeze(1), eye + strains).squeeze(1)
+        lattices = lattice
+    else:
+        eye = torch.eye(3, dtype=torch.float32, device=device)[None, :, :]
+        lattices = torch.matmul(lattice, eye + strain)
+        strains = torch.repeat_interleave(strain, n_atoms, dim=0)
+        coords = torch.matmul(coords.unsqueeze(1), eye + strains).squeeze(1)
 
     lattice_index = torch.repeat_interleave(torch.arange(pairs_count.shape[0], device=device), pairs_count)
     pair_lattices = lattices[lattice_index]
@@ -97,29 +96,28 @@ class custom_graph(object):
         self.r_cut = r_cut
         self.a_cut = a_cut
         self.pbc = pbc
-        self.adp = AseAtomsAdaptor()
         self.atom_refs = atom_refs
         
     def transform(self, crystal):
-        struc = self.adp.get_structure(crystal)
-        i, j, offsets, d_ij = find_neighbors(np.array(struc.cart_coords), np.array(struc.lattice.matrix), self.r_cut, np.array(self.pbc, dtype=np.int32))
+        coords = np.asarray(crystal.get_positions(), dtype=np.float64)
+        lattice = np.asarray(crystal.cell.array, dtype=np.float64)
+        atom_fea = np.asarray(crystal.get_atomic_numbers(), dtype=np.int64).reshape(-1, 1)
+
+        i, j, offsets, d_ij = find_neighbors(coords, lattice, self.r_cut, np.array(self.pbc, dtype=np.int32))
         nbr_atoms = np.array([i, j], dtype=np.int32).T
         
         if len(nbr_atoms) == 0:
-            n_bond_pairs_atom = np.zeros(len(struc), dtype=np.int32)
+            n_bond_pairs_atom = np.zeros(len(crystal), dtype=np.int32)
             n_bond_pairs_bond = np.array([], dtype=np.int32)
             bond_pairs_indices = np.array([], dtype=np.int32).reshape(-1, 2)
         else:
-            n_bond_pairs_atom, n_bond_pairs_bond, bond_pairs_indices = compute_tp_cc(nbr_atoms, d_ij, self.a_cut, len(struc))
+            n_bond_pairs_atom, n_bond_pairs_bond, bond_pairs_indices = compute_tp_cc(nbr_atoms, d_ij, self.a_cut, len(crystal))
         
         n_bond_pairs_struc = np.array([np.sum(n_bond_pairs_atom)], dtype=np.int32)
-
-        atom_fea = np.vstack([struc[i].specie.number
-                              for i in range(len(struc))])
         
         ref_energy = np.sum(self.atom_refs[atom_fea])
         
-        return atom_fea, np.array(struc.cart_coords), d_ij, offsets, np.array(struc.lattice.matrix), nbr_atoms, bond_pairs_indices, n_bond_pairs_atom, n_bond_pairs_bond, n_bond_pairs_struc, ref_energy
+        return atom_fea, coords, d_ij, offsets, lattice, nbr_atoms, bond_pairs_indices, n_bond_pairs_atom, n_bond_pairs_bond, n_bond_pairs_struc, ref_energy
 
 def collate_fn(data):
     """
@@ -213,20 +211,84 @@ class ASECalculator(Calculator):
         self.model.eval()
         self.graph = custom_graph()
 
+    def _model_energy(self, atom_fea, pair_dist_ij, n_atoms, triple_dist_ij, triple_dist_ik, triple_a_jik, nbr_atoms, n_bond_pairs_bond, bond_pairs_indices, ref_energy):
+        energy = self.model(
+            atom_fea,
+            pair_dist_ij,
+            n_atoms,
+            triple_dist_ij,
+            triple_dist_ik,
+            triple_a_jik,
+            nbr_atoms,
+            n_bond_pairs_bond,
+            bond_pairs_indices,
+        )
+        return energy.view(-1) + ref_energy
+
+    def get_energy(self, data):
+        atom_fea, coords, _d_ij, offsets, lattice, n_atoms, pairs_count, nbr_atoms, bond_pairs_indices, _n_bond_pairs_struc, _n_bond_pairs_atom, n_bond_pairs_bond, ref_energy = data
+
+        with torch.no_grad():
+            _, _, pair_dist_ij, triple_dist_ij, triple_dist_ik, triple_a_jik = _pair_and_triple_features(
+                coords, offsets, lattice, n_atoms, pairs_count, nbr_atoms, bond_pairs_indices, self.device
+            )
+            return self._model_energy(
+                atom_fea,
+                pair_dist_ij,
+                n_atoms,
+                triple_dist_ij,
+                triple_dist_ik,
+                triple_a_jik,
+                nbr_atoms,
+                n_bond_pairs_bond,
+                bond_pairs_indices,
+                ref_energy,
+            )
+
+    def get_ef(self, data):
+        atom_fea, coords, _d_ij, offsets, lattice, n_atoms, pairs_count, nbr_atoms, bond_pairs_indices, _n_bond_pairs_struc, _n_bond_pairs_atom, n_bond_pairs_bond, ref_energy = data
+
+        coords = coords.requires_grad_(True)
+        _, _, pair_dist_ij, triple_dist_ij, triple_dist_ik, triple_a_jik = _pair_and_triple_features(
+            coords, offsets, lattice, n_atoms, pairs_count, nbr_atoms, bond_pairs_indices, self.device
+        )
+        ener_pred = self._model_energy(
+            atom_fea,
+            pair_dist_ij,
+            n_atoms,
+            triple_dist_ij,
+            triple_dist_ik,
+            triple_a_jik,
+            nbr_atoms,
+            n_bond_pairs_bond,
+            bond_pairs_indices,
+            ref_energy,
+        )
+        force_pred = torch.autograd.grad(ener_pred, coords, torch.ones_like(ener_pred), retain_graph=False, create_graph=False)[0]
+        force_pred = -1.0 * force_pred
+        return ener_pred, force_pred
+
     def get_efs(self, data):
-        
-        atom_fea, coords, d_ij, offsets, lattice, n_atoms, pairs_count, nbr_atoms, bond_pairs_indices, n_bond_pairs_struc, n_bond_pairs_atom, n_bond_pairs_bond, ref_energy = data
-        
+        atom_fea, coords, _d_ij, offsets, lattice, n_atoms, pairs_count, nbr_atoms, bond_pairs_indices, _n_bond_pairs_struc, _n_bond_pairs_atom, n_bond_pairs_bond, ref_energy = data
+
         coords = coords.requires_grad_(True)
         strain = torch.zeros_like(lattice, dtype=torch.float32).requires_grad_(True)
         _, lattices, pair_dist_ij, triple_dist_ij, triple_dist_ik, triple_a_jik = _pair_and_triple_features(
             coords, offsets, lattice, n_atoms, pairs_count, nbr_atoms, bond_pairs_indices, self.device, strain
         )
         volumes = torch.linalg.det(lattices)
-                
-        ener_pred = self.model(atom_fea, pair_dist_ij, n_atoms, triple_dist_ij, triple_dist_ik, triple_a_jik, nbr_atoms, n_bond_pairs_bond, bond_pairs_indices)
-
-        ener_pred = ener_pred.view(-1) + ref_energy
+        ener_pred = self._model_energy(
+            atom_fea,
+            pair_dist_ij,
+            n_atoms,
+            triple_dist_ij,
+            triple_dist_ik,
+            triple_a_jik,
+            nbr_atoms,
+            n_bond_pairs_bond,
+            bond_pairs_indices,
+            ref_energy,
+        )
         force_pred, stress_pred = torch.autograd.grad(ener_pred, [coords, strain], torch.ones_like(ener_pred), retain_graph=False, create_graph=False) #kk 添加
         force_pred = -1.0 * force_pred
         stress_pred = 1. / volumes[:, None, None] * stress_pred * 160.21766208
@@ -328,13 +390,27 @@ class ASECalculator(Calculator):
         data = self.graph.transform(atoms)
         data = collate_fn(data)
         data = [x.to(self.device) for x in data]
-        ener, force, stress = self.get_efs(data)
+
+        need_forces = "forces" in properties
+        need_stress = "stress" in properties
+
+        if need_stress:
+            ener, force, stress = self.get_efs(data)
+        elif need_forces:
+            ener, force = self.get_ef(data)
+            stress = None
+        else:
+            ener = self.get_energy(data)
+            force = None
+            stress = None
 
         self.results.update(
             energy=ener.detach().cpu().numpy().ravel().item(),
             free_energy=ener.detach().cpu().numpy().ravel().item(),
-            forces=force.detach().cpu().numpy(),
-            stress=stress[0].detach().cpu().numpy() 
         )
+        if force is not None:
+            self.results["forces"] = force.detach().cpu().numpy()
+        if stress is not None:
+            self.results["stress"] = stress[0].detach().cpu().numpy()
 
         del data, ener, force, stress  

--- a/gptff/model/mpredict.py
+++ b/gptff/model/mpredict.py
@@ -1,31 +1,15 @@
 import numpy as np
-from ase import Atoms, units
+from ase import Atoms
 from ase.calculators.calculator import Calculator, all_changes
 from pymatgen.io.ase import AseAtomsAdaptor
-from pymatgen.core import Structure
 from gptff.model import model 
-import ast
-import pandas as pd
-import json
 import torch
-from typing import Optional, Union, Sequence
-from ase.optimize.bfgs import BFGS
-from ase.optimize.bfgslinesearch import BFGSLineSearch
-from ase.optimize.fire import FIRE
-from ase.optimize.lbfgs import LBFGS, LBFGSLineSearch
-from ase.optimize.mdmin import MDMin
-from ase.optimize.optimize import Optimizer
-from ase.optimize.sciopt import SciPyFminBFGS, SciPyFminCG
-from ase.constraints import ExpCellFilter, StrainFilter
-from ase.phonons import Phonons
+from typing import Optional, Sequence
 from tqdm import tqdm
-# import matplotlib.pyplot as plt
-from pymatgen.core.composition import Composition
-from scipy import interpolate
 from gptff.utils_.compute_tp import compute_tp_cc
 from gptff.utils_.compute_nb import find_neighbors
 from gptff.utils_.data import collate_fn as training_collate_fn
-import os, psutil, time, gc
+import os, psutil, time
 
 # lightweight, ASE-proof file logger (same idea as prior mem_log)
 def _mem_log_path():
@@ -45,6 +29,38 @@ class CFG:
     def __init__(self, d):
         for k, v in d.items():
             setattr(self, k, v)
+
+
+def _load_checkpoint(model_path, device):
+    try:
+        return torch.load(model_path, map_location=torch.device(device), weights_only=False)
+    except TypeError:
+        return torch.load(model_path, map_location=torch.device(device))
+
+
+def _pair_and_triple_features(coords, offsets, lattice, n_atoms, pairs_count, nbr_atoms, bond_pairs_indices, device, strain=None):
+    eye = torch.eye(3, dtype=torch.float32, device=device)[None, :, :]
+    if strain is None:
+        strain = torch.zeros_like(lattice, dtype=torch.float32)
+
+    lattices = torch.matmul(lattice, eye + strain)
+    strains = torch.repeat_interleave(strain, n_atoms, dim=0)
+    coords = torch.matmul(coords.unsqueeze(1), eye + strains).squeeze(1)
+
+    lattice_index = torch.repeat_interleave(torch.arange(pairs_count.shape[0], device=device), pairs_count)
+    pair_lattices = lattices[lattice_index]
+    offset_dist = torch.matmul(offsets[:, None, :], pair_lattices).squeeze(1)
+
+    pair_vec_ij = coords[nbr_atoms[:, 1], :] + offset_dist - coords[nbr_atoms[:, 0], :]
+    pair_dist_ij = torch.linalg.norm(pair_vec_ij, dim=1)
+
+    triple_vec_ij = pair_vec_ij[bond_pairs_indices[:, 0]]
+    triple_vec_ik = pair_vec_ij[bond_pairs_indices[:, 1]]
+    triple_dist_ij = pair_dist_ij[bond_pairs_indices[:, 0]]
+    triple_dist_ik = pair_dist_ij[bond_pairs_indices[:, 1]]
+    triple_a_jik = (triple_vec_ij * triple_vec_ik).sum(dim=1) / (triple_dist_ij * triple_dist_ik)
+    triple_a_jik = torch.clamp(triple_a_jik, -1.0, 1.0) * (1 - 1e-6)
+    return coords, lattices, pair_dist_ij, triple_dist_ij, triple_dist_ik, triple_a_jik
 
 atom_refs = np.array([ 0.00000000e+00, -3.46535853e+00, -7.56101906e-01, -3.46224791e+00,
        -4.77600176e+00, -8.03619240e+00, -8.40374071e+00, -7.76814618e+00,
@@ -89,7 +105,12 @@ class custom_graph(object):
         i, j, offsets, d_ij = find_neighbors(np.array(struc.cart_coords), np.array(struc.lattice.matrix), self.r_cut, np.array(self.pbc, dtype=np.int32))
         nbr_atoms = np.array([i, j], dtype=np.int32).T
         
-        n_bond_pairs_atom, n_bond_pairs_bond, bond_pairs_indices = compute_tp_cc(nbr_atoms, d_ij, self.a_cut, len(struc))
+        if len(nbr_atoms) == 0:
+            n_bond_pairs_atom = np.zeros(len(struc), dtype=np.int32)
+            n_bond_pairs_bond = np.array([], dtype=np.int32)
+            bond_pairs_indices = np.array([], dtype=np.int32).reshape(-1, 2)
+        else:
+            n_bond_pairs_atom, n_bond_pairs_bond, bond_pairs_indices = compute_tp_cc(nbr_atoms, d_ij, self.a_cut, len(struc))
         
         n_bond_pairs_struc = np.array([np.sum(n_bond_pairs_atom)], dtype=np.int32)
 
@@ -176,7 +197,7 @@ class ASECalculator(Calculator):
     def __init__(self, model_path, device='cuda', **kwargs):
         super().__init__(**kwargs)
 
-        self.state = torch.load(model_path, map_location=torch.device(device))
+        self.state = _load_checkpoint(model_path, device)
 
         cfg = CFG(self.state['cfg'])
         cfg.device = device
@@ -187,9 +208,9 @@ class ASECalculator(Calculator):
         self.device = device
         self.model.load_state_dict(self.state['state_dict'])
         self.model = self.model.to(device)
-        # Ensure deterministic inference: disable dropout etc. by switching to eval mode
+        for param in self.model.parameters():
+            param.requires_grad_(False)
         self.model.eval()
-        #print("eval")
         self.graph = custom_graph()
 
     def get_efs(self, data):
@@ -198,35 +219,14 @@ class ASECalculator(Calculator):
         
         coords = coords.requires_grad_(True)
         strain = torch.zeros_like(lattice, dtype=torch.float32).requires_grad_(True)
-    
-        lattices = torch.matmul(lattice, torch.eye(3, dtype=torch.float32)[None, :, :].to(self.device) + strain)
-
+        _, lattices, pair_dist_ij, triple_dist_ij, triple_dist_ik, triple_a_jik = _pair_and_triple_features(
+            coords, offsets, lattice, n_atoms, pairs_count, nbr_atoms, bond_pairs_indices, self.device, strain
+        )
         volumes = torch.linalg.det(lattices)
-        strains = torch.repeat_interleave(strain, n_atoms, dim=0)
-        coords = torch.matmul(coords.unsqueeze(1), torch.eye(3, dtype=torch.float32)[None, :, :].to(self.device) + strains).squeeze()
-
-        lattices = lattices[torch.repeat_interleave(torch.arange(pairs_count.shape[0]).to(self.device), pairs_count)]
-        offset_dist = torch.matmul(offsets[:, None, :], lattices).squeeze()
-
-        vec_diff_ij = (
-                coords[nbr_atoms[:, 1], :]
-                + offset_dist
-                - coords[nbr_atoms[:, 0], :]
-            )
-
-        pair_vec_ij = vec_diff_ij
-        pair_dist_ij = torch.sqrt(torch.matmul(pair_vec_ij[:, None, :], pair_vec_ij[:, :, None])).squeeze()
-        triple_vec_ij = pair_vec_ij[bond_pairs_indices[:, 0]].squeeze()
-        triple_vec_ik = pair_vec_ij[bond_pairs_indices[:, 1]].squeeze()
-        triple_dist_ij = pair_dist_ij[bond_pairs_indices[:, 0]].squeeze()
-        triple_dist_ik = pair_dist_ij[bond_pairs_indices[:, 1]].squeeze()
-        triple_a_jik = torch.matmul(triple_vec_ij[:, None, :], triple_vec_ik[:, :, None]).squeeze(-1) / (triple_dist_ij[:, None] * triple_dist_ik[:, None])
-        triple_a_jik = torch.clamp(triple_a_jik, -1.0, 1.0) * (1 - 1e-6)
-        triple_a_jik = triple_a_jik.squeeze()
                 
         ener_pred = self.model(atom_fea, pair_dist_ij, n_atoms, triple_dist_ij, triple_dist_ik, triple_a_jik, nbr_atoms, n_bond_pairs_bond, bond_pairs_indices)
 
-        ener_pred = ener_pred.squeeze() + ref_energy
+        ener_pred = ener_pred.view(-1) + ref_energy
         force_pred, stress_pred = torch.autograd.grad(ener_pred, [coords, strain], torch.ones_like(ener_pred), retain_graph=False, create_graph=False) #kk 添加
         force_pred = -1.0 * force_pred
         stress_pred = 1. / volumes[:, None, None] * stress_pred * 160.21766208
@@ -242,29 +242,12 @@ class ASECalculator(Calculator):
         """
         atom_fea, coords, offsets, lattice, n_atoms, pairs_count, nbr_atoms, bond_pairs_indices, n_bond_pairs_bond, _e, _f, _s, ref_energy = data
 
-        eye = torch.eye(3, dtype=torch.float32, device=self.device)[None, :, :]
-        strain = torch.zeros_like(lattice, dtype=torch.float32)
-        lattices = torch.matmul(lattice, eye + strain)
-
-        strains = torch.repeat_interleave(strain, n_atoms, dim=0)
-        coords = torch.matmul(coords.unsqueeze(1), eye + strains).squeeze(1)
-
-        lattices = lattices[torch.repeat_interleave(torch.arange(pairs_count.shape[0], device=self.device), pairs_count)]
-        offset_dist = torch.matmul(offsets[:, None, :], lattices).squeeze()
-
-        vec_diff_ij = coords[nbr_atoms[:, 1], :] + offset_dist - coords[nbr_atoms[:, 0], :]
-        pair_vec_ij = vec_diff_ij
-        pair_dist_ij = torch.sqrt(torch.matmul(pair_vec_ij[:, None, :], pair_vec_ij[:, :, None])).squeeze()
-        triple_vec_ij = pair_vec_ij[bond_pairs_indices[:, 0]].squeeze()
-        triple_vec_ik = pair_vec_ij[bond_pairs_indices[:, 1]].squeeze()
-        triple_dist_ij = pair_dist_ij[bond_pairs_indices[:, 0]].squeeze()
-        triple_dist_ik = pair_dist_ij[bond_pairs_indices[:, 1]].squeeze()
-        triple_a_jik = torch.matmul(triple_vec_ij[:, None, :], triple_vec_ik[:, :, None]).squeeze(-1) / (triple_dist_ij[:, None] * triple_dist_ik[:, None])
-        triple_a_jik = torch.clamp(triple_a_jik, -1.0, 1.0) * (1 - 1e-6)
-        triple_a_jik = triple_a_jik.squeeze()
+        _, _, pair_dist_ij, triple_dist_ij, triple_dist_ik, triple_a_jik = _pair_and_triple_features(
+            coords, offsets, lattice, n_atoms, pairs_count, nbr_atoms, bond_pairs_indices, self.device
+        )
 
         ener_pred = self.model(atom_fea, pair_dist_ij, n_atoms, triple_dist_ij, triple_dist_ik, triple_a_jik, nbr_atoms, n_bond_pairs_bond, bond_pairs_indices)
-        ener_pred = ener_pred.squeeze() + ref_energy
+        ener_pred = ener_pred.view(-1) + ref_energy
         return ener_pred
 
     def _atoms_to_training_row(self, atoms: Atoms):

--- a/gptff/model/torchsim.py
+++ b/gptff/model/torchsim.py
@@ -32,6 +32,7 @@ NeighborListFn = Callable[
     [Tensor, Tensor, Tensor, Tensor, Tensor, bool],
     tuple[Tensor, Tensor, Tensor],
 ]
+EV_PER_ANG3_TO_GPA = 160.21766208
 
 
 def _sort_edges_by_center(
@@ -119,6 +120,11 @@ class GPTFFTorchSimModel(ModelInterface):
     format.  It replaces the ASE/Cython graph path with TorchSim's batched
     neighbor list, so a single SimState can contain one structure or a batch of
     structures/replicas.
+
+    Stress is computed by differentiating the energy with respect to an
+    affine strain tensor.  The default stress unit is eV/A^3, which matches
+    TorchSim pressure utilities; pass ``stress_unit="GPa"`` to match GPTFF's
+    ASE calculator output.
     """
 
     def __init__(
@@ -132,10 +138,12 @@ class GPTFFTorchSimModel(ModelInterface):
         r_cut: float = 5.0,
         a_cut: float = 3.5,
         reference_energies: np.ndarray = atom_refs,
+        stress_unit: str = "ev_per_ang3",
     ) -> None:
         super().__init__()
-        if compute_stress:
-            raise NotImplementedError("GPTFFTorchSimModel currently supports energy and forces, but not stress.")
+        stress_unit_normalized = stress_unit.lower()
+        if stress_unit_normalized not in {"ev_per_ang3", "gpa"}:
+            raise ValueError("stress_unit must be 'ev_per_ang3' or 'GPa'.")
 
         self._device = torch.device(device)
         self._dtype = dtype
@@ -145,6 +153,7 @@ class GPTFFTorchSimModel(ModelInterface):
         self.r_cut = float(r_cut)
         self.a_cut = float(a_cut)
         self.neighbor_list_fn = neighbor_list_fn
+        self.stress_unit = stress_unit_normalized
 
         state = _load_checkpoint(model_path, self._device)
         cfg = CFG(state["cfg"])
@@ -162,7 +171,12 @@ class GPTFFTorchSimModel(ModelInterface):
         refs = torch.as_tensor(reference_energies, dtype=self._dtype, device=self._device)
         self.register_buffer("atom_refs", refs, persistent=False)
 
-    def _build_gptff_inputs(self, state: ts.SimState, positions: Tensor) -> tuple[Tensor, ...]:
+    def _build_gptff_inputs(
+        self,
+        state: ts.SimState,
+        positions: Tensor,
+        strain: Tensor | None = None,
+    ) -> tuple[Tensor, ...]:
         system_idx = state.system_idx.to(device=self._device, dtype=torch.long)
         atomic_numbers = state.atomic_numbers.to(device=self._device, dtype=torch.long).view(-1)
         cell = state.row_vector_cell.to(device=self._device, dtype=self._dtype)
@@ -190,9 +204,18 @@ class GPTFFTorchSimModel(ModelInterface):
         mapping_system = mapping_system[keep_edges]
         unit_shifts = unit_shifts[keep_edges]
 
-        shifts = ts.transforms.compute_cell_shifts(cell, unit_shifts, mapping_system)
+        if strain is None:
+            feature_cell = cell
+            feature_positions = positions
+        else:
+            eye = torch.eye(3, dtype=self._dtype, device=self._device)[None, :, :]
+            feature_cell = torch.matmul(cell, eye + strain)
+            atom_strain = strain.index_select(0, system_idx)
+            feature_positions = torch.matmul(positions.unsqueeze(1), eye + atom_strain).squeeze(1)
 
-        pair_vec = positions[nbr_atoms[:, 1]] + shifts - positions[nbr_atoms[:, 0]]
+        shifts = ts.transforms.compute_cell_shifts(feature_cell, unit_shifts, mapping_system)
+
+        pair_vec = feature_positions[nbr_atoms[:, 1]] + shifts - feature_positions[nbr_atoms[:, 0]]
         pair_dist = torch.linalg.norm(pair_vec, dim=1)
         nbr_atoms, pair_vec, pair_dist, mapping_system = _sort_edges_by_center(
             nbr_atoms, pair_vec, pair_dist, mapping_system
@@ -223,12 +246,17 @@ class GPTFFTorchSimModel(ModelInterface):
             n_bond_pairs_bond,
             bond_pairs_indices,
             ref_energy,
+            feature_cell,
         )
 
     def forward(self, state: ts.SimState, **kwargs) -> dict[str, Tensor]:
         del kwargs
         positions = state.positions.to(device=self._device, dtype=self._dtype).detach().clone()
         positions.requires_grad_(self._compute_forces)
+        strain = None
+        if self._compute_stress:
+            row_cell = state.row_vector_cell.to(device=self._device, dtype=self._dtype)
+            strain = torch.zeros_like(row_cell, requires_grad=True)
 
         (
             atom_fea,
@@ -241,7 +269,8 @@ class GPTFFTorchSimModel(ModelInterface):
             n_bond_pairs_bond,
             bond_pairs_indices,
             ref_energy,
-        ) = self._build_gptff_inputs(state, positions)
+            feature_cell,
+        ) = self._build_gptff_inputs(state, positions, strain=strain)
 
         energy = self.gptff_model(
             atom_fea,
@@ -256,16 +285,37 @@ class GPTFFTorchSimModel(ModelInterface):
         ).view(-1) + ref_energy
 
         results: dict[str, Tensor] = {"energy": energy.detach()}
+        grad_targets: list[Tensor] = []
         if self._compute_forces:
-            forces = -torch.autograd.grad(
+            grad_targets.append(positions)
+        if self._compute_stress:
+            if strain is None:
+                raise RuntimeError("Internal error: stress requested without a strain tensor.")
+            grad_targets.append(strain)
+        if grad_targets:
+            grads = torch.autograd.grad(
                 energy,
-                positions,
+                grad_targets,
                 grad_outputs=torch.ones_like(energy),
                 retain_graph=False,
                 create_graph=False,
-            )[0]
+            )
+        else:
+            grads = ()
+
+        grad_idx = 0
+        if self._compute_forces:
+            forces = -grads[grad_idx]
+            grad_idx += 1
             results["forces"] = forces.detach()
+        if self._compute_stress:
+            stress = grads[grad_idx]
+            volumes = torch.linalg.det(feature_cell)
+            stress = stress / volumes[:, None, None]
+            if self.stress_unit == "gpa":
+                stress = stress * EV_PER_ANG3_TO_GPA
+            results["stress"] = stress.detach()
         return results
 
 
-__all__ = ["GPTFFTorchSimModel"]
+__all__ = ["GPTFFTorchSimModel", "EV_PER_ANG3_TO_GPA"]

--- a/gptff/model/torchsim.py
+++ b/gptff/model/torchsim.py
@@ -1,0 +1,271 @@
+"""TorchSim interface for GPTFF models.
+
+This module is intentionally optional: importing GPTFF's ASE calculator does
+not require TorchSim, while users who have torch-sim-atomistic installed can
+use GPTFFTorchSimModel directly with TorchSim integrators.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from gptff.model import model
+from gptff.model.mpredict import CFG, _load_checkpoint, atom_refs
+
+try:
+    import torch_sim as ts
+    from torch_sim.models.interface import ModelInterface
+    from torch_sim.neighbors import torchsim_nl
+except ImportError as exc:  # pragma: no cover - exercised only without TorchSim
+    raise ImportError(
+        "GPTFFTorchSimModel requires torch-sim-atomistic. "
+        "Install GPTFF with the torchsim extra or install torch-sim-atomistic separately."
+    ) from exc
+
+
+NeighborListFn = Callable[
+    [Tensor, Tensor, Tensor, Tensor, Tensor, bool],
+    tuple[Tensor, Tensor, Tensor],
+]
+
+
+def _sort_edges_by_center(
+    nbr_atoms: Tensor,
+    pair_vec: Tensor,
+    pair_dist: Tensor,
+    mapping_system: Tensor,
+) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+    """Keep all edge-aligned tensors in center-atom order."""
+
+    if nbr_atoms.shape[0] <= 1:
+        return nbr_atoms, pair_vec, pair_dist, mapping_system
+
+    centers = nbr_atoms[:, 0]
+    try:
+        order = torch.argsort(centers, stable=True)
+    except TypeError:  # older PyTorch fallback
+        order = torch.argsort(centers)
+    return nbr_atoms[order], pair_vec[order], pair_dist[order], mapping_system[order]
+
+
+def _angle_edge_pairs(nbr_atoms: Tensor, pair_dist: Tensor, angle_cutoff: float) -> tuple[Tensor, Tensor]:
+    """Build GPTFF ordered three-body edge pairs from TorchSim edges.
+
+    GPTFF represents an angle j-i-k by two directed bonds i->j and i->k.  For
+    every angle-cutoff bond used as the target i->j, all other angle-cutoff
+    bonds with the same center atom become i->k candidates.  The returned rows
+    are ordered by target edge, matching GPTFF's n_bond_pairs_bond contract.
+    """
+
+    num_edges = int(nbr_atoms.shape[0])
+    device = nbr_atoms.device
+    n_bond_pairs_bond = torch.zeros(num_edges, dtype=torch.long, device=device)
+    if num_edges == 0:
+        return torch.empty((0, 2), dtype=torch.long, device=device), n_bond_pairs_bond
+
+    eligible = torch.nonzero(pair_dist <= angle_cutoff, as_tuple=False).view(-1)
+    if eligible.numel() == 0:
+        return torch.empty((0, 2), dtype=torch.long, device=device), n_bond_pairs_bond
+
+    centers = nbr_atoms[eligible, 0]
+    _, counts = torch.unique_consecutive(centers, return_counts=True)
+    if counts.numel() == 0 or int(counts.max().item()) < 2:
+        return torch.empty((0, 2), dtype=torch.long, device=device), n_bond_pairs_bond
+
+    counts_per_edge = torch.repeat_interleave(counts, counts)
+    n_bond_pairs_bond[eligible] = counts_per_edge - 1
+
+    group_count = int(counts.shape[0])
+    max_count = int(counts.max().item())
+    group_ids = torch.repeat_interleave(torch.arange(group_count, device=device), counts)
+    group_starts = torch.repeat_interleave(torch.cumsum(counts, dim=0) - counts, counts)
+    positions_in_group = torch.arange(eligible.numel(), device=device) - group_starts
+
+    padded = eligible.new_full((group_count, max_count), -1)
+    padded[group_ids, positions_in_group] = eligible
+
+    target_edges = padded[:, :, None].expand(-1, -1, max_count)
+    other_edges = padded[:, None, :].expand(-1, max_count, -1)
+    keep = (target_edges >= 0) & (other_edges >= 0) & (target_edges != other_edges)
+    bond_pairs_indices = torch.stack((target_edges[keep], other_edges[keep]), dim=1)
+    return bond_pairs_indices.to(dtype=torch.long), n_bond_pairs_bond
+
+
+def _triple_features(pair_vec: Tensor, pair_dist: Tensor, bond_pairs_indices: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+    if bond_pairs_indices.numel() == 0:
+        empty = pair_dist.new_empty((0,))
+        return empty, empty, empty
+
+    pair_j = bond_pairs_indices[:, 0]
+    pair_k = bond_pairs_indices[:, 1]
+    triple_vec_ij = pair_vec[pair_j]
+    triple_vec_ik = pair_vec[pair_k]
+    triple_dist_ij = pair_dist[pair_j]
+    triple_dist_ik = pair_dist[pair_k]
+    triple_a_jik = (triple_vec_ij * triple_vec_ik).sum(dim=1) / (triple_dist_ij * triple_dist_ik)
+    triple_a_jik = torch.clamp(triple_a_jik, -1.0, 1.0) * (1 - 1e-6)
+    return triple_dist_ij, triple_dist_ik, triple_a_jik
+
+
+class GPTFFTorchSimModel(ModelInterface):
+    """TorchSim-native GPTFF model wrapper.
+
+    The wrapper reuses GPTFF's pretrained V1/V2 model classes and checkpoint
+    format.  It replaces the ASE/Cython graph path with TorchSim's batched
+    neighbor list, so a single SimState can contain one structure or a batch of
+    structures/replicas.
+    """
+
+    def __init__(
+        self,
+        model_path: str | Path,
+        device: str | torch.device = "cuda",
+        dtype: torch.dtype = torch.float32,
+        compute_forces: bool = True,
+        compute_stress: bool = False,
+        neighbor_list_fn: NeighborListFn = torchsim_nl,
+        r_cut: float = 5.0,
+        a_cut: float = 3.5,
+        reference_energies: np.ndarray = atom_refs,
+    ) -> None:
+        super().__init__()
+        if compute_stress:
+            raise NotImplementedError("GPTFFTorchSimModel currently supports energy and forces, but not stress.")
+
+        self._device = torch.device(device)
+        self._dtype = dtype
+        self._compute_forces = bool(compute_forces)
+        self._compute_stress = bool(compute_stress)
+        self._memory_scales_with = "n_atoms_x_density"
+        self.r_cut = float(r_cut)
+        self.a_cut = float(a_cut)
+        self.neighbor_list_fn = neighbor_list_fn
+
+        state = _load_checkpoint(model_path, self._device)
+        cfg = CFG(state["cfg"])
+        cfg.device = self._device
+        if state["cfg"]["transformer_activate"]:
+            self.gptff_model = model.tModLodaer_t(cfg)
+        else:
+            self.gptff_model = model.tModLodaer(cfg)
+        self.gptff_model.load_state_dict(state["state_dict"])
+        self.gptff_model = self.gptff_model.to(device=self._device, dtype=self._dtype)
+        for parameter in self.gptff_model.parameters():
+            parameter.requires_grad_(False)
+        self.gptff_model.eval()
+
+        refs = torch.as_tensor(reference_energies, dtype=self._dtype, device=self._device)
+        self.register_buffer("atom_refs", refs, persistent=False)
+
+    def _build_gptff_inputs(self, state: ts.SimState, positions: Tensor) -> tuple[Tensor, ...]:
+        system_idx = state.system_idx.to(device=self._device, dtype=torch.long)
+        atomic_numbers = state.atomic_numbers.to(device=self._device, dtype=torch.long).view(-1)
+        cell = state.row_vector_cell.to(device=self._device, dtype=self._dtype)
+        pbc = state.pbc.to(device=self._device)
+        cutoff = torch.tensor(self.r_cut, device=self._device, dtype=self._dtype)
+
+        edge_index, mapping_system, unit_shifts = self.neighbor_list_fn(
+            positions,
+            cell,
+            pbc,
+            cutoff,
+            system_idx,
+            False,
+        )
+        nbr_atoms = edge_index.T.to(dtype=torch.long)
+        mapping_system = mapping_system.to(device=self._device, dtype=torch.long)
+        unit_shifts = unit_shifts.to(device=self._device, dtype=self._dtype)
+
+        # GPTFF's original Cython neighbor search excludes identical atom
+        # indices even when a periodic image is inside the cutoff.  TorchSim's
+        # self_interaction=False only removes the zero-distance self edge, so we
+        # filter periodic self images here to preserve pretrained-model inputs.
+        non_self = nbr_atoms[:, 0] != nbr_atoms[:, 1]
+        nbr_atoms = nbr_atoms[non_self]
+        mapping_system = mapping_system[non_self]
+        unit_shifts = unit_shifts[non_self]
+
+        shifts = ts.transforms.compute_cell_shifts(cell, unit_shifts, mapping_system)
+
+        pair_vec = positions[nbr_atoms[:, 1]] + shifts - positions[nbr_atoms[:, 0]]
+        pair_dist = torch.linalg.norm(pair_vec, dim=1)
+        nbr_atoms, pair_vec, pair_dist, mapping_system = _sort_edges_by_center(
+            nbr_atoms, pair_vec, pair_dist, mapping_system
+        )
+        del mapping_system
+
+        bond_pairs_indices, n_bond_pairs_bond = _angle_edge_pairs(nbr_atoms, pair_dist, self.a_cut)
+        triple_dist_ij, triple_dist_ik, triple_a_jik = _triple_features(
+            pair_vec,
+            pair_dist,
+            bond_pairs_indices,
+        )
+
+        n_systems = int(state.n_systems)
+        n_atoms = torch.bincount(system_idx, minlength=n_systems).to(dtype=torch.long)
+        ref_per_atom = self.atom_refs.index_select(0, atomic_numbers)
+        ref_energy = ref_per_atom.new_zeros((n_systems,))
+        ref_energy = torch.index_add(ref_energy, 0, system_idx, ref_per_atom)
+
+        return (
+            atomic_numbers.view(-1, 1),
+            pair_dist,
+            n_atoms,
+            triple_dist_ij,
+            triple_dist_ik,
+            triple_a_jik,
+            nbr_atoms,
+            n_bond_pairs_bond,
+            bond_pairs_indices,
+            ref_energy,
+        )
+
+    def forward(self, state: ts.SimState, **kwargs) -> dict[str, Tensor]:
+        del kwargs
+        positions = state.positions.to(device=self._device, dtype=self._dtype).detach().clone()
+        positions.requires_grad_(self._compute_forces)
+
+        (
+            atom_fea,
+            pair_dist,
+            n_atoms,
+            triple_dist_ij,
+            triple_dist_ik,
+            triple_a_jik,
+            nbr_atoms,
+            n_bond_pairs_bond,
+            bond_pairs_indices,
+            ref_energy,
+        ) = self._build_gptff_inputs(state, positions)
+
+        energy = self.gptff_model(
+            atom_fea,
+            pair_dist,
+            n_atoms,
+            triple_dist_ij,
+            triple_dist_ik,
+            triple_a_jik,
+            nbr_atoms,
+            n_bond_pairs_bond,
+            bond_pairs_indices,
+        ).view(-1) + ref_energy
+
+        results: dict[str, Tensor] = {"energy": energy.detach()}
+        if self._compute_forces:
+            forces = -torch.autograd.grad(
+                energy,
+                positions,
+                grad_outputs=torch.ones_like(energy),
+                retain_graph=False,
+                create_graph=False,
+            )[0]
+            results["forces"] = forces.detach()
+        return results
+
+
+__all__ = ["GPTFFTorchSimModel"]

--- a/gptff/model/torchsim.py
+++ b/gptff/model/torchsim.py
@@ -181,14 +181,14 @@ class GPTFFTorchSimModel(ModelInterface):
         mapping_system = mapping_system.to(device=self._device, dtype=torch.long)
         unit_shifts = unit_shifts.to(device=self._device, dtype=self._dtype)
 
-        # GPTFF's original Cython neighbor search excludes identical atom
-        # indices even when a periodic image is inside the cutoff.  TorchSim's
-        # self_interaction=False only removes the zero-distance self edge, so we
-        # filter periodic self images here to preserve pretrained-model inputs.
-        non_self = nbr_atoms[:, 0] != nbr_atoms[:, 1]
-        nbr_atoms = nbr_atoms[non_self]
-        mapping_system = mapping_system[non_self]
-        unit_shifts = unit_shifts[non_self]
+        # Match GPTFF's Cython neighbor search: exclude only the true zero-shift
+        # self edge, while retaining periodic images of the same atom.
+        zero_shift = (unit_shifts == 0).all(dim=1)
+        zero_self_edge = (nbr_atoms[:, 0] == nbr_atoms[:, 1]) & zero_shift
+        keep_edges = ~zero_self_edge
+        nbr_atoms = nbr_atoms[keep_edges]
+        mapping_system = mapping_system[keep_edges]
+        unit_shifts = unit_shifts[keep_edges]
 
         shifts = ts.transforms.compute_cell_shifts(cell, unit_shifts, mapping_system)
 

--- a/gptff/trainer/trainer.py
+++ b/gptff/trainer/trainer.py
@@ -1,4 +1,5 @@
 import argparse
+from contextlib import nullcontext
 import os
 import shutil
 import sys
@@ -22,7 +23,7 @@ from joblib import Parallel, delayed
 
 from gptff.utils_.data import Mydataset, collate_fn, CosineAnnealingWarmupRestarts
 from gptff.model.model import tModLodaer, tModLodaer_t
-from torch.cuda.amp import autocast, GradScaler
+from torch.amp import autocast, GradScaler
 from datetime import datetime
 import json
 import gc
@@ -137,8 +138,16 @@ def mae(prediction, target):
 
     return torch.mean(torch.abs(target - prediction))
 
+def amp_context():
+    if str(CFG.device).startswith('cuda'):
+        return autocast('cuda')
+    return nullcontext()
+
+def make_grad_scaler():
+    return GradScaler('cuda', enabled=str(CFG.device).startswith('cuda'))
+
 def train(train_loader, model, criterion, optimizer, pbar_trn):
-    scaler = GradScaler()
+    scaler = make_grad_scaler()
 
     batch_time = AverageMeter()
     data_time = AverageMeter()
@@ -174,11 +183,11 @@ def train(train_loader, model, criterion, optimizer, pbar_trn):
             continue
 
         strains = torch.repeat_interleave(strain, n_atoms, dim=0)
-        coords = torch.matmul(coords.unsqueeze(1), torch.eye(3, dtype=torch.float32)[None, :, :].to(CFG.device) + strains).squeeze()
+        coords = torch.matmul(coords.unsqueeze(1), torch.eye(3, dtype=torch.float32)[None, :, :].to(CFG.device) + strains).squeeze(1)
 
         lattices = lattices[torch.repeat_interleave(torch.arange(pairs_count.shape[0]).to(CFG.device), pairs_count)]
         
-        offset_dist = torch.matmul(offsets[:, None, :], lattices).squeeze()
+        offset_dist = torch.matmul(offsets[:, None, :], lattices).squeeze(1)
 
         vec_diff_ij = (
                 coords[nbr_atoms[:, 1], :]
@@ -187,27 +196,26 @@ def train(train_loader, model, criterion, optimizer, pbar_trn):
             )
 
         pair_vec_ij = vec_diff_ij
-        pair_dist_ij = torch.sqrt(torch.matmul(pair_vec_ij[:, None, :], pair_vec_ij[:, :, None])).squeeze()
-        triple_vec_ij = pair_vec_ij[bond_pairs_indices[:, 0]].squeeze()
-        triple_vec_ik = pair_vec_ij[bond_pairs_indices[:, 1]].squeeze()
-        triple_dist_ij = pair_dist_ij[bond_pairs_indices[:, 0]].squeeze()
-        triple_dist_ik = pair_dist_ij[bond_pairs_indices[:, 1]].squeeze()
-        triple_a_jik = torch.matmul(triple_vec_ij[:, None, :], triple_vec_ik[:, :, None]).squeeze(-1) / (triple_dist_ij[:, None] * triple_dist_ik[:, None])
+        pair_dist_ij = torch.linalg.norm(pair_vec_ij, dim=1)
+        triple_vec_ij = pair_vec_ij[bond_pairs_indices[:, 0]]
+        triple_vec_ik = pair_vec_ij[bond_pairs_indices[:, 1]]
+        triple_dist_ij = pair_dist_ij[bond_pairs_indices[:, 0]]
+        triple_dist_ik = pair_dist_ij[bond_pairs_indices[:, 1]]
+        triple_a_jik = (triple_vec_ij * triple_vec_ik).sum(dim=1) / (triple_dist_ij * triple_dist_ik)
         triple_a_jik = torch.clamp(triple_a_jik, -1.0, 1.0) * (1 - 1e-6)
-        triple_a_jik = triple_a_jik.squeeze()
         
         # compute output
 
-        with autocast():
+        with amp_context():
 
             ener_pred = model(atom_fea, pair_dist_ij, n_atoms, triple_dist_ij, triple_dist_ik, triple_a_jik, nbr_atoms, n_bond_pairs_bond, bond_pairs_indices)
-            ener_pred = ener_pred.squeeze() + ref_energy
+            ener_pred = ener_pred.view(-1) + ref_energy
             force_pred, stress_pred = torch.autograd.grad(ener_pred, [coords, strain], torch.ones_like(ener_pred), retain_graph=True, create_graph=True)
             force_pred = -1.0 * force_pred
             stress_pred = 1. / volumes[:, None, None] * stress_pred * CFG.unit_trans
 
-            ener_pred = ener_pred.squeeze() / n_atoms
-            target_energy = target_energy.squeeze() / n_atoms
+            ener_pred = ener_pred.view(-1) / n_atoms
+            target_energy = target_energy.view(-1) / n_atoms
             
             e_loss = criterion(ener_pred, target_energy)
             f_loss = criterion(force_pred.view(-1), target_forces.view(-1))
@@ -289,13 +297,13 @@ def validate(val_loader, model, criterion, pbar_trn, pbar_val):
             continue
         
         strains = torch.repeat_interleave(strain, n_atoms, dim=0)
-        coords = torch.matmul(coords.unsqueeze(1), torch.eye(3, dtype=torch.float32)[None, :, :].to(CFG.device) + strains).squeeze()
+        coords = torch.matmul(coords.unsqueeze(1), torch.eye(3, dtype=torch.float32)[None, :, :].to(CFG.device) + strains).squeeze(1)
 
         lattices = lattices[torch.repeat_interleave(torch.arange(pairs_count.shape[0]).to(CFG.device), pairs_count)]
 
-        with autocast():
+        with amp_context():
             
-            offset_dist = torch.matmul(offsets[:, None, :], lattices).squeeze()
+            offset_dist = torch.matmul(offsets[:, None, :], lattices).squeeze(1)
             # offset_dist = torch.matmul(lattices, offsets[:, :, None]).squeeze()
 
             vec_diff_ij = (
@@ -305,26 +313,25 @@ def validate(val_loader, model, criterion, pbar_trn, pbar_val):
                 )
 
             pair_vec_ij = vec_diff_ij
-            pair_dist_ij = torch.sqrt(torch.matmul(pair_vec_ij[:, None, :], pair_vec_ij[:, :, None])).squeeze()
-            triple_vec_ij = pair_vec_ij[bond_pairs_indices[:, 0]].squeeze()
-            triple_vec_ik = pair_vec_ij[bond_pairs_indices[:, 1]].squeeze()
-            triple_dist_ij = pair_dist_ij[bond_pairs_indices[:, 0]].squeeze()
-            triple_dist_ik = pair_dist_ij[bond_pairs_indices[:, 1]].squeeze()
-            triple_a_jik = torch.matmul(triple_vec_ij[:, None, :], triple_vec_ik[:, :, None]).squeeze(-1) / (triple_dist_ij[:, None] * triple_dist_ik[:, None])
+            pair_dist_ij = torch.linalg.norm(pair_vec_ij, dim=1)
+            triple_vec_ij = pair_vec_ij[bond_pairs_indices[:, 0]]
+            triple_vec_ik = pair_vec_ij[bond_pairs_indices[:, 1]]
+            triple_dist_ij = pair_dist_ij[bond_pairs_indices[:, 0]]
+            triple_dist_ik = pair_dist_ij[bond_pairs_indices[:, 1]]
+            triple_a_jik = (triple_vec_ij * triple_vec_ik).sum(dim=1) / (triple_dist_ij * triple_dist_ik)
             triple_a_jik = torch.clamp(triple_a_jik, -1., 1.) * (1 - 1e-6)
-            triple_a_jik = triple_a_jik.squeeze()
             
 
             ener_pred = model(atom_fea, pair_dist_ij, n_atoms, triple_dist_ij, triple_dist_ik, triple_a_jik, nbr_atoms, n_bond_pairs_bond, bond_pairs_indices)
             
-            ener_pred = ener_pred.squeeze() + ref_energy
+            ener_pred = ener_pred.view(-1) + ref_energy
 
             force_pred, stress_pred = torch.autograd.grad(ener_pred, [coords, strain], torch.ones_like(ener_pred), retain_graph=True, create_graph=True)
             force_pred = -1.0 * force_pred
             stress_pred = 1. / volumes[:, None, None] * stress_pred * 160.21766208
 
-            ener_pred = ener_pred.squeeze() / n_atoms
-            target_energy = target_energy.squeeze() / n_atoms
+            ener_pred = ener_pred.view(-1) / n_atoms
+            target_energy = target_energy.view(-1) / n_atoms
 
             e_loss = criterion(ener_pred.view(-1), target_energy.view(-1))
             f_loss = criterion(force_pred.view(-1), target_forces.view(-1))

--- a/gptff/trainer/trainer.py
+++ b/gptff/trainer/trainer.py
@@ -422,3 +422,7 @@ def main():
 
         if is_best:
             shutil.copyfile('curr_checkpoint.pth', 'best_checkpoint.pth')
+
+
+if __name__ == "__main__":
+    main()

--- a/gptff/utils_/data.py
+++ b/gptff/utils_/data.py
@@ -10,15 +10,63 @@ import ast
 import numpy as np
 import torch
 from pymatgen.core.structure import Structure
-from torch.utils.data import Dataset, DataLoader
-from torch.utils.data.dataloader import default_collate
-from torch.utils.data.sampler import SubsetRandomSampler
+from pymatgen.core.periodic_table import Element
+from torch.utils.data import Dataset
 import pandas as pd
 from gptff.utils_.compute_tp import compute_tp_cc
 from gptff.utils_.compute_nb import find_neighbors
 
 from torch.optim.lr_scheduler import ReduceLROnPlateau,_LRScheduler
 import math
+
+
+@functools.lru_cache(maxsize=None)
+def _atomic_number(symbol):
+    return int(Element(symbol).Z)
+
+
+def _literal(value):
+    if isinstance(value, str):
+        return ast.literal_eval(value)
+    return value
+
+
+def _array_literal(value, dtype=np.float32):
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            value = ast.literal_eval(value)
+    return np.asarray(value, dtype=dtype)
+
+
+def _site_symbol(site):
+    species = site.get("species")
+    if isinstance(species, list) and len(species) == 1:
+        specie = species[0]
+        if isinstance(specie, dict):
+            return specie.get("element") or specie.get("label")
+    if isinstance(species, dict):
+        return species.get("element") or species.get("label")
+    return site.get("label")
+
+
+def structure_arrays(structure_value):
+    structure_dict = _literal(structure_value)
+    try:
+        sites = structure_dict["sites"]
+        coords = np.asarray([site["xyz"] for site in sites], dtype=np.float64)
+        lattice = np.asarray(structure_dict["lattice"]["matrix"], dtype=np.float64)
+        symbols = [_site_symbol(site) for site in sites]
+        if any(symbol is None for symbol in symbols):
+            raise KeyError("missing site element")
+        atom_fea = np.asarray([[_atomic_number(symbol)] for symbol in symbols], dtype=np.int64)
+        return atom_fea, coords, lattice
+    except Exception:
+        structure = Structure.from_dict(structure_dict)
+        atom_fea = np.asarray([[site.specie.number] for site in structure], dtype=np.int64)
+        return atom_fea, np.asarray(structure.cart_coords, dtype=np.float64), np.asarray(structure.lattice.matrix, dtype=np.float64)
+
 
 class Mydataset(Dataset):
     def __init__(self, df, pbc=[1, 1, 1], r_cut=5.0, a_cut=3.5):
@@ -27,46 +75,47 @@ class Mydataset(Dataset):
         a_cut: cutoff for angles
         """
 
-        self.df = df
+        self.df = df.reset_index(drop=True)
         self.r_cut = r_cut
         self.a_cut = a_cut
-        self.pbc = pbc
+        self.pbc = np.asarray(pbc, dtype=np.int32)
+        self.structures = self.df["structure"].tolist()
+        self.energies = self.df["energy"].to_numpy(dtype=np.float32)
+        self.forces = self.df["forces"].tolist()
+        self.stresses = self.df["stress"].tolist()
+        self.ref_energies = self.df["ref_energy"].to_numpy(dtype=np.float32)
 
     def __len__(self):
-        return len(self.df)
+        return len(self.structures)
 
     @functools.lru_cache(maxsize=None)  # Cache loaded structures
     def __getitem__(self, idx):
         try:
-            struc = Structure.from_dict(ast.literal_eval(self.df['structure'][idx]))
-
-            energy = self.df['energy'][idx]
-            forces = np.array(ast.literal_eval(self.df['forces'][idx]))
-            stress = np.array(ast.literal_eval(self.df['stress'][idx])) * -0.1
-            ref_energy = np.array(self.df['ref_energy'][idx])
+            atom_fea, coords, lattice = structure_arrays(self.structures[idx])
+            energy = self.energies[idx]
+            forces = _array_literal(self.forces[idx], dtype=np.float32)
+            stress = _array_literal(self.stresses[idx], dtype=np.float32) * -0.1
+            ref_energy = self.ref_energies[idx]
 
         except Exception:
             idx = random.randint(0, len(self) - 1)
             return self.__getitem__(idx)
         
-        i, j, offset, d_ij = find_neighbors(np.array(struc.cart_coords), np.array(struc.lattice.matrix), self.r_cut, np.array(self.pbc, dtype=np.int32))
+        i, j, offset, d_ij = find_neighbors(coords, lattice, self.r_cut, self.pbc)
         nbr_atoms = np.array([i, j], dtype=np.int32).T
 
         if len(nbr_atoms) == 0:
             # when there is no neighbor pair, keep consistent var names and shapes
-            n_bond_pairs_atom = np.array([0] * len(struc), dtype=np.int32)
+            n_bond_pairs_atom = np.zeros(coords.shape[0], dtype=np.int32)
             n_bond_pairs_bond = np.array([], dtype=np.int32)
             bond_pairs_indices = np.array([], dtype=np.int32).reshape(-1, 2)
         else:
-            n_bond_pairs_atom, n_bond_pairs_bond, bond_pairs_indices = compute_tp_cc(nbr_atoms, d_ij, self.a_cut, len(struc))
+            n_bond_pairs_atom, n_bond_pairs_bond, bond_pairs_indices = compute_tp_cc(nbr_atoms, d_ij, self.a_cut, coords.shape[0])
         
 
         n_bond_pairs_struc = np.array([np.sum(n_bond_pairs_atom)], dtype=np.int32)
-
-        atom_fea = np.vstack([struc[i].specie.number
-                              for i in range(len(struc))])
         
-        return atom_fea, np.array(struc.cart_coords), d_ij, offset, np.array(struc.lattice.matrix), nbr_atoms, bond_pairs_indices, n_bond_pairs_atom, n_bond_pairs_bond, n_bond_pairs_struc, energy, forces, stress, ref_energy 
+        return atom_fea, coords, d_ij, offset, lattice, nbr_atoms, bond_pairs_indices, n_bond_pairs_atom, n_bond_pairs_bond, n_bond_pairs_struc, energy, forces, stress, ref_energy
     
 
 def collate_fn(data):

--- a/gptff/utils_/source/utils.cc
+++ b/gptff/utils_/source/utils.cc
@@ -101,7 +101,7 @@ Results_ptr *cal_tp(int *n_bond_pairs_atom, int *n_bond_pairs_bond, const int *n
     delete[] num_bonds_atom;
     results->num_tps = num_tps;
     return results;
-}   
+}
 
 // ----kkk Added explicit free helpers for Cython wrappers ----
 extern "C" void free_results2(Results_ptr2* p) {
@@ -182,7 +182,11 @@ Results_ptr2 *find_neighbors_cc(const double *coords, const double *lattice, con
 
                                 double dist_r = std::sqrt(dist_vec[0] * dist_vec[0] + dist_vec[1] * dist_vec[1] + dist_vec[2] * dist_vec[2]);
                             
-                                if ((dist_r <= cutoff) && (center_idx != j_atom_idx)){
+                                bool zero_self_edge = (center_idx == j_atom_idx) &&
+                                                      (offset_xyz[0] == 0) &&
+                                                      (offset_xyz[1] == 0) &&
+                                                      (offset_xyz[2] == 0);
+                                if ((dist_r <= cutoff) && !zero_self_edge){
                                     center_indices.push_back(center_idx);
                                     neigh_indices.push_back(j_atom_idx);
                                     dist_list.push_back(dist_r);
@@ -206,4 +210,4 @@ Results_ptr2 *find_neighbors_cc(const double *coords, const double *lattice, con
     results->offset_list = offset_list;
 
     return results;
-}   
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,17 @@ name = "gptff"
 version = "1.0.1"
 description = "Graph-based Pretrained Transformer Force Field."
 authors = [{ name = "Fankai Xie", email = "fankaixiee@gmail.com" }]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 dependencies = [
-    "ase==3.26.0",
-    "torch>=1.6",
+    "ase>=3.26,<3.29",
+    "torch>=2.0",
+    "numpy",
+    "pandas",
     "pymatgen",
     "scikit-learn",
-    "psutil"
+    "psutil",
+    "tqdm"
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
     "tqdm"
 ]
 
+[project.optional-dependencies]
+torchsim = ["torch-sim-atomistic>=0.6"]
+
 
 [tool.setuptools.packages]
 find = { include = ["gptff*"], exclude = ["test*"] }

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,4 @@ setup(
             extra_compile_args=["-std=c++11", "-g"],
         ),
     ],
-    setup_requires=["Cython"]
 )


### PR DESCRIPTION
This PR updates GPTFF for newer Python/ASE/PyTorch environments while preserving compatibility with existing GPTFF V1 and V2 pretrained checkpoints.

  Main changes:
  - Update ASE calculator internals for newer ASE versions.
  - Keep GPTFF V1 and V2 checkpoint loading compatible.
  - Fix small-atom and single-atom shape handling in graph features.
  - Preserve periodic self-image neighbors while excluding only zero-displacement self
  edges.
  - Split ASE calculator energy, force, and stress paths to avoid unnecessary gradient
  work.
  - Add direct ASE graph construction to reduce conversion overhead.
  - Remove repeated model-side graph tensor construction in forward paths.
  - Add lightweight training structure parsing improvements.
  - Add GPTFF TorchSim model interface with energy, force, and stress output while
  keeping the original ASE calculator API unchanged.
  - Fix V2 transformer training/backward behavior on CUDA by using a math SDP path when
  higher-order gradients are needed.